### PR TITLE
implement get_root_functions

### DIFF
--- a/src/napari_workflows/_workflow.py
+++ b/src/napari_workflows/_workflow.py
@@ -120,6 +120,19 @@ class Workflow():
                             origins.append(source)
         return origins
 
+    def get_root_functions(self):
+        """
+        Return a list of workflow steps that have root images as an input
+        """
+        roots = self.roots()
+        wf_step_with_rootinput = []
+        for result, task in self._tasks.items():
+                for source in task:
+                    if isinstance(source, str):
+                        if source in roots:
+                            wf_step_with_rootinput.append(result)
+        return wf_step_with_rootinput
+
     def followers_of(self, item):
         """
         Return all names of images that are produced out of a given image.


### PR DESCRIPTION
Hey Robert @haesleinhuepf 
This is a function that I use for loading into napari, which could live in the actual workflow class. It is useful to initialise a workflow as the first step is to load the functions with root images as inputs and selecting the right input images. Maybe this function is too specific for the workflow class though? Maybe we can discuss here, which is why I have marked it as a draft PR.