### PR TITLE
adding remove viewers function to workflows

### DIFF
--- a/src/napari_workflows/_workflow.py
+++ b/src/napari_workflows/_workflow.py
@@ -148,6 +148,15 @@ class Workflow():
         """
         return [l for l in self._tasks.keys() if len(self.followers_of(l)) == 0]
 
+    def remove_viewers(self):
+        """
+        Removes all Viewer objects from the _tasks tupules, which cause errors 
+        when saving workflows.
+        """
+        for key,value in self._tasks.items():
+            viewer_removed = tuple([entry for entry in value if not isinstance(entry, Viewer)])
+            self._tasks[key] = viewer_removed
+
     def __str__(self):
         out = "Workflow:\n"
         for result, task in self._tasks.items():


### PR DESCRIPTION
Hey Robert @haesleinhuepf,
I have added this function to the workflow object because loading a workflow seems to add the Viewer instance to the items of the ._tasks dictionary. The viewer then causes errors when saving the workflow. Since the original workflow does not contain the viewer objects they don't seem to be important for saving and loading so they can be removed with this function.