### PR TITLE
Use `stackview` to display images in notebooks instead of numpy arrays.

### DIFF
--- a/src/napari_workflows/_workflow.py
+++ b/src/napari_workflows/_workflow.py
@@ -7,7 +7,6 @@ METADATA_WORKFLOW_VALID_KEY = "workflow_valid"
 
 CURRENT_TIME_FRAME_DATA = "current_time_frame_data"
 
-
 class Workflow():
     """
     The Workflow class encapsulates a dictionary that works as dask-task-graph. The task
@@ -162,7 +161,6 @@ class Workflow():
 
             out = out + result + " <- "+ str(print_params) + "\n"
         return out
-
 
 class WorkflowManager():
     """
@@ -482,7 +480,7 @@ def _generate_python_code(workflow: Workflow, viewer: "napari.Viewer", notebook:
     str
         python code
     """
-    imports = ["from skimage.io import imread"]
+    imports = ["from skimage.io import imread", "import stackview"]
     code = []
 
     import dask
@@ -589,7 +587,7 @@ def _generate_python_code(workflow: Workflow, viewer: "napari.Viewer", notebook:
                 if use_napari:
                     _viewer_add_image_and_notebook_screenshot(code, viewer, notebook, result_name, key)
                 elif notebook:
-                    code.append(result_name + "\n")
+                    code.append(f"stackview.insight({result_name})\n")
 
             except KeyError:
                 try:
@@ -605,7 +603,7 @@ def _generate_python_code(workflow: Workflow, viewer: "napari.Viewer", notebook:
                         if use_napari:
                             _viewer_add_image_and_notebook_screenshot(code, viewer, notebook, result_name, key)
                         elif notebook:
-                            code.append(result_name + "\n")
+                            code.append(f"stackview.insight({result_name})\n")
 
                     else:
                         if notebook:


### PR DESCRIPTION
<sup>This message was generated by [git-bob](https://github.com/haesleinhuepf/git-bob) (version: 0.2.3, model: gpt-4o-2024-08-06), an experimental AI-based assistant. It can make mistakes and has [limitations](https://github.com/haesleinhuepf/git-bob?tab=readme-ov-file#limitations). Check its messages carefully.</sup>

Updated the code in `src/napari_workflows/_workflow.py` to import `stackview` and use `stackview.insight()` to display images in notebooks, addressing the issue of images appearing as numpy arrays instead of as visual images.

closes #38